### PR TITLE
fix access to freed memory

### DIFF
--- a/SuffixTreePyBinding/pycommons.h
+++ b/SuffixTreePyBinding/pycommons.h
@@ -9,8 +9,9 @@ using namespace std;
 inline string pyString_toString(PyObject* s) {
 	auto* sobj = PyUnicode_AsUTF8String(s);  //automatically deref when return
 	const char* c = PyBytes_AsString(sobj);
+	string str(c);
 	Py_DECREF(sobj);
-	return string(c);
+	return str;
 }
 
 inline vector<string> listString_toVector(PyObject* list) {


### PR DESCRIPTION
Partially fixes #2 (without the special unicode character).

The test code for this bug:
```python
def test_bug2():
    data = [
        '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
        '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
        '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
        '0000000000000000000000000000000000000000000000000000000000000001',
        '000000000000000000000000000000000000000000000000000000000000000',
        '0000000000000000000000000000000000000000000000000000000001',
        '0000000000000000000000000000000000000000000000001', '000000000000000000000000000000000000000000000',
        '0000000000000000000000000000000000000000000', '000000000000000000000000000000000000000000',
        '00000000000000000000000000000000000000000', '0000000000000000000000000000000000000000',
        '0000000000000000000000000000000000000001', '000000000000000000000000000000000000000',
        '00000000000000000000000000000000000000',
        # '00000000000000000000000000000000000000ᴅ',
        '000000000000000000000000000000000000', '00000000000000000000000000000000000',
        '0000000000000000000000000000000000', '000000000000000000000000000000000', '00000000000000000000000000000000',
        '0000000000000000000000000000000', '0000000000000000000000000000001', '000000000000000000000000000000',
        '00000000000000000000000000000', '0000000000000000000000000000', '000000000000000000000000000',
        '0000000000000000000000000', '0000000000000000000000001', '000000000000000000000000', '00000000000000000000000',
        '00000000000000000000001', '0000000000000000000000', '0000000000000000000001', '000000000000000000000']

    tree = SuffixQueryTree(False, data)

    assert not tree.findStringIdx('\x7f')
    assert len(tree.getStrings()) == len(data)
```